### PR TITLE
Align with AUTH48 changes (aka RFC9882)

### DIFF
--- a/ML-DSA-Module-2024.asn
+++ b/ML-DSA-Module-2024.asn
@@ -1,6 +1,6 @@
 ML-DSA-Module-2024
   { iso(1) member-body(2) us(840) rsadsi(113549) pkcs(1) pkcs9(9)
-    id-smime(16) id-mod(0) id-mod-ml-dsa-2024(TBD1) }
+    id-smime(16) id-mod(0) id-mod-ml-dsa-2024(83) }
 
 DEFINITIONS IMPLICIT TAGS ::= BEGIN
 
@@ -13,7 +13,7 @@ IMPORTS SIGNATURE-ALGORITHM, SMIME-CAPS
     id-mod-algorithmInformation-02(58) }
 
 sa-ml-dsa-44, sa-ml-dsa-65, sa-ml-dsa-87
-  FROM X509-ML-DSA-2024 -- From [I-D.ietf-lamps-dilithium-certificates]
+  FROM X509-ML-DSA-2024 -- From [RFC9881]
   { iso(1) identified-organization(3) dod(6) internet(1)
     security(5) mechanisms(5) pkix(7) id-mod(0)
     id-mod-x509-ml-dsa-2024(119) } ;

--- a/draft-ietf-lamps-cms-ml-dsa.md
+++ b/draft-ietf-lamps-cms-ml-dsa.md
@@ -42,11 +42,11 @@ normative:
   FIPS204: DOI.10.6028/NIST.FIPS.204
   CSOR:
     target: https://csrc.nist.gov/projects/computer-security-objects-register/algorithm-registration
-    title: Computer Security Objects Register
+    title: Computer Security Objects Register (CSOR)
     author:
       name: National Institute of Standards and Technology
       ins: NIST
-    date: 2024-08-20
+    date: 2025-06-13
   RFC5652:
 
 informative:
@@ -55,10 +55,14 @@ informative:
   RFC5911:
   X680:
     target: https://www.itu.int/rec/T-REC-X.680
-    title: "Information Technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation. ITU-T Recommendation X.680 (2021) | ISO/IEC 8824-1:2021."
+    title: >
+      Information technology - Abstract Syntax Notation One (ASN.1): Specification of basic notation
     author:
       org: ITU-T
     date: February 2021
+    seriesinfo:
+      ITU-T Recommendation: X.680
+      ISO/IEC: 8824-1:2021
   KPLG2024:
     target: https://ia.cr/2024/138
     title: "Correction Fault Attacks on Randomized CRYSTALS-Dilithium"
@@ -74,6 +78,8 @@ informative:
     date: 2024
     format:
       PDF: https://eprint.iacr.org/2024/138.pdf
+    seriesinfo:
+      Cryptology ePrint Archive, Paper 2024/138
   WNGD2023:
     target: https://ia.cr/2023/1931
     title: "Single-Trace Side-Channel Attacks on CRYSTALS-Dilithium: Myth or Reality?"
@@ -89,23 +95,24 @@ informative:
     date: 2023
     format:
       PDF: https://eprint.iacr.org/2023/1931.pdf
+    seriesinfo:
+      Cryptology ePrint Archive, Paper 2023/1931
 ---
 
 --- abstract
 
 The Module-Lattice-Based Digital Signature Algorithm (ML-DSA), as defined by NIST in FIPS 204, is a post-quantum digital signature scheme that aims to be secure against an adversary in possession of a Cryptographically Relevant Quantum Computer (CRQC).
 This document specifies the conventions for using the ML-DSA signature algorithm with the Cryptographic Message Syntax (CMS).
-In addition, the algorithm identifier and public key syntax are provided.
+In addition, the algorithm identifier syntax is provided.
 
 
 --- middle
 
 # Introduction
 
-The Module-Lattice-Based Digital Signature Algorithm (ML-DSA) is a digital signature algorithm standardised by the US National Institute of Standards and Technology (NIST) as part of their post-quantum cryptography standardisation process.
-It is intended to be secure against both "traditional" cryptographic attacks, as well as attacks utilising a quantum computer.
+The Module-Lattice-Based Digital Signature Algorithm (ML-DSA) is a post-quantum digital signature algorithm standardised by the US National Institute of Standards and Technology (NIST) as part of their post-quantum cryptography standardisation process.
 It offers smaller signatures and significantly faster runtimes than SLH-DSA {{FIPS205}}, an alternative post-quantum signature algorithm also standardised by NIST.
-This document specifies the use of the ML-DSA in the CMS at three security levels: ML-DSA-44, ML-DSA-65, and ML-DSA-87.  See {{Appendix B of I-D.ietf-lamps-dilithium-certificates}} for more information on the security levels and key sizes of ML-DSA.
+This document specifies the use of ML-DSA in the CMS at three security levels: ML-DSA-44, ML-DSA-65, and ML-DSA-87.  See {{Appendix B of RFC9881}} for more information on the security levels and key sizes of ML-DSA.
 
 Prior to standardisation, ML-DSA was known as Dilithium.  ML-DSA and Dilithium are not compatible.
 
@@ -127,7 +134,7 @@ Many ASN.1 data structure types use the AlgorithmIdentifier type to identify cry
 In the CMS, AlgorithmIdentifiers are used to identify ML-DSA signatures in the signed-data content type.
 They may also appear in X.509 certificates used to verify those signatures.
 The same AlgorithmIdentifiers are used to identify ML-DSA public keys and signature algorithms.
-{{?I-D.ietf-lamps-dilithium-certificates}} describes the use of ML-DSA in X.509 certificates.
+{{?RFC9881}} describes the use of ML-DSA in X.509 certificates.
 The AlgorithmIdentifier type is defined as follows:
 
 ~~~ asn.1
@@ -171,21 +178,21 @@ id-ml-dsa-87 OBJECT IDENTIFIER ::= { sigAlgs 19 }
 
 ~~~
 
-# Signed-data Conventions
+# Signed-Data Conventions
 
-## Pure mode vs pre-hash mode {#pure-vs-pre-hash}
+## Pure Mode Versus Pre-Hash Mode {#pure-vs-pre-hash}
 
-{{RFC5652}} specifies that digital signatures for CMS are produced using a digest of the message to be signed, and the signer's private key.
-At the time of publication of that RFC, all signature algorithms supported in the CMS required a message digest to be calculated externally to that algorithm, which would then be supplied to the algorithm implementation when calculating and verifying signatures.
+{{RFC5652}} specifies that digital signatures for CMS are produced using a digest of the message to be signed and the signer's private key.
+At the time RFC 5652 was published, all signature algorithms supported in the CMS required a message digest to be calculated externally to that algorithm, which would then be supplied to the algorithm implementation when calculating and verifying signatures.
 Since then, EdDSA {{?RFC8032}}, SLH-DSA {{FIPS205}} and ML-DSA have also been standardised, and these algorithms support both a "pure" and "pre-hash" mode.
 In the pre-hash mode, a message digest (the "pre-hash") is calculated separately and supplied to the signature algorithm as described above.
 In the pure mode, the message to be signed or verified is instead supplied directly to the signature algorithm.
-When EdDSA {{?RFC8419}} and SLH-DSA {{?I-D.ietf-lamps-cms-sphincs-plus}} are used with CMS, only the pure mode of those algorithms is specified.
+When EdDSA {{?RFC8419}} and SLH-DSA {{?RFC9814}} are used with CMS, only the pure mode of those algorithms is specified.
 This is because in most situations, CMS signatures are computed over a set of signed attributes that contain a hash of the content, rather than being computed over the message content itself.
 Since signed attributes are typically small, use of pre-hash modes in the CMS wouldn't significantly reduce the size of the data to be signed, and hence offers no benefit.
 This document follows that convention and does not specify the use of ML-DSA's pre-hash mode ("HashML-DSA") in the CMS.
 
-## Signature generation and verification
+## Signature Generation and Verification
 
 {{RFC5652}} describes the two methods that are used to calculate and verify signatures in the CMS.
 One method is used when signed attributes are present in the signedAttrs field of the relevant SignerInfo, and another is used when signed attributes are absent.
@@ -198,27 +205,27 @@ The tag and length octets are not included.
 
 When signed attributes are included, ML-DSA (pure mode) signatures are computed over the complete DER encoding of the SignedAttrs value contained in the SignerInfo's signedAttrs field.
 As described in {{Section 5.4 of RFC5652}}, this encoding includes the tag and length octets, but an EXPLICIT SET OF tag is used rather than the IMPLICIT \[0\] tag that appears in the final message.
-The signedAttrs field MUST at minimum include a content-type attribute and a message-digest attribute.
+At a minimum, the signedAttrs field MUST include a content-type attribute and a message-digest attribute.
 The message-digest attribute contains a hash of the content of the signed-data, where the content is as described for the absent signed attributes case above.
 Recalculation of the hash value by the recipient is an important step in signature verification.
 
-{{Section 4 of ?I-D.ietf-lamps-cms-sphincs-plus}} describes how, when the content of a signed-data is large, performance may be improved by including signed attributes.
+{{Section 4 of ?RFC9814}} describes how, when the content of a signed-data is large, performance may be improved by including signed attributes.
 This is as true for ML-DSA as it is for SLH-DSA, although ML-DSA signature generation and verification is significantly faster than SLH-DSA.
 
 ML-DSA has a context string input that can be used to ensure that different signatures are generated for different application contexts.
 When using ML-DSA as specified in this document, the context string is set to the empty string.
 
-## SignerInfo content
+## SignerInfo Content
 
 When using ML-DSA, the fields of a SignerInfo are used as follows:
 
 digestAlgorithm:
 
-: Per {{Section 5.3 of RFC5652}}, the digestAlgorithm field identifies the message digest algorithm used by the signer, and any associated parameters.
-Each ML-DSA parameter set has a collision strength parameter, represented by the &lambda; (lambda) symbol in {{FIPS204}}.
+: Per {{Section 5.3 of RFC5652}}, the digestAlgorithm field identifies the message digest algorithm used by the signer and any associated parameters.
+Each ML-DSA parameter set has a collision strength parameter, represented by the "&lambda;" (GREEK SMALL LETTER LAMDA, U+03BB) symbol in {{FIPS204}}.
 When signers utilise signed attributes, their choice of digest algorithm may impact the overall security level of their signature.
 Selecting a digest algorithm that offers &lambda; bits of security strength against second preimage attacks and collision attacks is sufficient to meet the security level offered by a given parameter set, so long as the digest algorithm produces at least 2 * &lambda; bits of output.
-The overall security strength offered by an ML-DSA signature calculated over signed attributes is the floor of the digest algorithm's strength and the strength of the ML-DSA parameter set.
+The overall security strength offered by an ML-DSA signature calculated over signed attributes is constrained by either the digest algorithm's strength or the strength of the ML-DSA parameter set, whichever is lower.
 Verifiers MAY reject a signature if the signer's choice of digest algorithm does not meet the security requirements of their choice of ML-DSA parameter set.
 {{ml-dsa-digest-algs}} shows appropriate SHA-2 and SHA-3 digest algorithms for each parameter set.
 
@@ -234,11 +241,11 @@ As such, the considerations above and in {{ml-dsa-digest-algs}} do not apply.
 Nonetheless, in this case implementations MUST specify SHA-512 as the digestAlgorithm in order to minimise the likelihood of an interoperability failure.
 When processing a SignerInfo signed using ML-DSA, if no signed attributes are present, implementations MUST ignore the content of the digestAlgorithm field.
 
- | Signature algorithm | Digest Algorithms                                                           |
+ | Signature Algorithm | Digest Algorithms                                                           |
  | ML-DSA-44           | SHA-256, SHA-384, SHA-512, SHA3-256, SHA3-384, SHA3-512, SHAKE128, SHAKE256 |
  | ML-DSA-65           | SHA-384, SHA-512, SHA3-384, SHA3-512, SHAKE256                              |
  | ML-DSA-87           | SHA-512, SHA3-512, SHAKE256                                                 |
- {: #ml-dsa-digest-algs title="Suitable digest algorithms for ML-DSA"}
+ {: #ml-dsa-digest-algs title="Suitable Digest Algorithms for ML-DSA"}
 
 signatureAlgorithm:
 
@@ -248,68 +255,57 @@ signatureAlgorithm:
  | ML-DSA-44           | id-ml-dsa-44             |
  | ML-DSA-65           | id-ml-dsa-65             |
  | ML-DSA-87           | id-ml-dsa-87             |
- {: #tab-oids title="Signature algorithm identifier OIDs for ML-DSA"}
+ {: #tab-oids title="Signature Algorithm Identifier OIDs for ML-DSA"}
 
  signature:
 
  : The signature field contains the signature value resulting from the use of the ML-DSA signature algorithm identified by the signatureAlgorithm field.
- The ML-DSA (pure mode) signature generation operation is specified in Section 5.2 of {{FIPS204}}, and the signature verification operation is specified in Section 5.3 of {{FIPS204}}.
+ The ML-DSA (pure mode) signature-generation operation is specified in Section 5.2 of {{FIPS204}}, and the signature-verification operation is specified in Section 5.3 of {{FIPS204}}.
  Note that {{Section 5.6 of RFC5652}} places further requirements on the successful verification of a signature.
 
 # Security Considerations
 
-The security considerations in {{RFC5652}} and {{!I-D.ietf-lamps-dilithium-certificates}} apply to this specification.
+The security considerations in {{RFC5652}} and {{!RFC9881}} apply to this specification.
 
 Security of the ML-DSA private key is critical.
 Compromise of the private key will enable an adversary to forge arbitrary signatures.
 
-ML-DSA depends on high quality random numbers that are suitable for use in cryptography.
+ML-DSA depends on high-quality random numbers that are suitable for use in cryptography.
 The use of inadequate pseudo-random number generators (PRNGs) to generate such values can significantly undermine the security properties offered by a cryptographic algorithm.
-For instance, an attacker may find it much easier to reproduce the PRNG environment that produced any private keys, searching the resulting small set of possibilities, rather than brute force searching the whole key space.
+For instance, an attacker may find it much easier to reproduce the PRNG environment that produced any private keys, searching the resulting small set of possibilities, rather than brute-force searching the whole key space.
 The generation of random numbers of a sufficient level of quality for use in cryptography is difficult; see Section 3.6.1 of {{FIPS204}} for some additional information.
 
 By default, ML-DSA signature generation uses randomness from two sources: fresh random data generated during signature generation, and precomputed random data included in the signer's private key.
 This is referred to as the "hedged" variant of ML-DSA.
-Inclusion of both sources of random can help mitigate against faulty random number generators, side-channel attacks and fault attacks.
+Inclusion of both sources of random data can help mitigate against faulty random number generators, side-channel attacks, and fault attacks.
 {{FIPS204}} also permits creating deterministic signatures using just the precomputed random data in the signer's private key.
 The same verification algorithm is used to verify both hedged and deterministic signatures, so this choice does not affect interoperability.
 The signer SHOULD NOT use the deterministic variant of ML-DSA on platforms where side-channel attacks or fault attacks are a concern.
-Side channel attacks and fault attacks against ML-DSA are an active area of research {{WNGD2023}} {{KPLG2024}}.
+Side-channel attacks and fault attacks against ML-DSA are an active area of research {{WNGD2023}} {{KPLG2024}}.
 Future protection against these styles of attack may involve interoperable changes to the implementation of ML-DSA's internal functions.
 Implementers SHOULD consider implementing such protection measures if it would be beneficial for their particular use cases.
 
 To avoid algorithm substitution attacks, the CMSAlgorithmProtection attribute defined in {{!RFC6211}} SHOULD be included in signed attributes.
 
 # Operational Considerations
-If ML-DSA signing is implemented in a hardware device such as hardware security module (HSM) or portable cryptographic token, implementers might want to avoid sending the full content to the device for performance reasons.
-By including signed attributes, which necessarily include the message-digest attribute and the content-type attribute as described in Section 5.3 of {{RFC5652}}, the much smaller set of signed attributes are sent to the device for signing.
+If ML-DSA signing is implemented in a hardware device such as a hardware security module (HSM) or a portable cryptographic token, implementers might want to avoid sending the full content to the device for performance reasons.
+By including signed attributes, which necessarily includes the message-digest attribute and the content-type attribute as described in Section 5.3 of {{RFC5652}}, the much smaller set of signed attributes are sent to the device for signing.
 
-Additionally, the pure variant of ML-DSA does support a form of pre-hash via external calculation of the &mu; (mu) "message representative" value described in Section 6.2 of {{FIPS204}}.
+Additionally, the pure variant of ML-DSA does support a form of pre-hash via external calculation of the "&mu;" (GREEK SMALL LETTER MU, U+03BC) "message representative" value described in Section 6.2 of {{FIPS204}}.
 This value may "optionally be computed in a different cryptographic module" and supplied to the hardware device, rather than requiring the entire message to be transmitted.
-Appendix D of {{?I-D.ietf-lamps-dilithium-certificates}} describes use of external &mu; calculations in further detail.
+Appendix D of {{?RFC9881}} describes use of external &mu; calculations in further detail.
 
 # IANA Considerations
 
-For the ASN.1 module found in {{asn1}}, IANA is requested to assign an object identifier for the module identifier (TBD1) with a description of "id-mod-ml-dsa-2024".
-This should be allocated in the "SMI Security for S/MIME Module Identifier" registry (1.2.840.113549.1.9.16.0).
+For the ASN.1 module in {{asn1}}, IANA has assigned the following object identifier in the "SMI Security for S/MIME Module Identifier (1.2.840.113549.1.9.16.0)" registry.
 
-
-# Acknowledgments
-
-The authors would like to thank the following people for their contributions and reviews that helped shape this document: Viktor Dukhovni, Russ Housley, Panos Kampanakis, Mike Ounsworth, Falko Strenzke, Sean Turner, and Wei-Jun Wang.
-
-This document was heavily influenced by {{?RFC8419}}, {{?I-D.ietf-lamps-cms-sphincs-plus}}, and {{?I-D.ietf-lamps-dilithium-certificates}}.
-Thanks go to the authors of those documents.
-
+| Decimal | Description        | Reference |
+| 83      | id-mod-ml-dsa-2024 | RFC 9882  |
+{: #tab-asn1-oid title="Object Identifier Assignments"}
 
 --- back
 
 # ASN.1 Module {#asn1}
-
-<aside markdown="block">
-RFC EDITOR: Please replace the reference to [I-D.ietf-lamps-dilithium-certificates]
-in the ASN.1 module below with a reference the corresponding published RFC.
-</aside>
 
 ~~~ asn.1
 <CODE BEGINS>
@@ -320,7 +316,7 @@ in the ASN.1 module below with a reference the corresponding published RFC.
 # Examples
 
 This appendix contains example signed-data encodings.
-They can be verified using the example public keys and certificates specified in Appendix C of {{?I-D.ietf-lamps-dilithium-certificates}}.
+They can be verified using the example public keys and certificates specified in Appendix C of {{?RFC9881}}.
 
 The following is an example of a signed-data with a single ML-DSA-44 signer, with signed attributes included:
 
@@ -351,3 +347,11 @@ The following is an example of a signed-data with a single ML-DSA-87 signer, wit
 ~~~
 {::include ./examples/mldsa87-signed-attrs.txt}
 ~~~
+
+# Acknowledgments
+{:numbered="false"}
+
+The authors would like to thank the following people for their contributions and reviews that helped shape this document: Viktor Dukhovni, Russ Housley, Panos Kampanakis, Mike Ounsworth, Falko Strenzke, Sean Turner, and Wei-Jun Wang.
+
+This document was heavily influenced by {{?RFC8419}}, {{?RFC9814}}, and {{?RFC9881}}.
+Thanks go to the authors of those documents.


### PR DESCRIPTION
The only differences will be the refs:

1. Sean and I don't know how to make it refer to: https://www.rfc-editor.org/info/
instead of https://www.rfc-editor.org/rfc/
for the RFC references.

2. I think maybe the DOI dereference from the tools looks slightly different than the format from the RFC editor.

In both instances it does not matter because they point to the same URI.